### PR TITLE
Feat: 이미지 업로드 버튼 구현

### DIFF
--- a/src/api/image/index.ts
+++ b/src/api/image/index.ts
@@ -1,0 +1,15 @@
+import ApiManager from "..";
+import { ImageDTO } from "../../types/image/dto";
+
+export const prepareImageUpload = async (): Promise<number> => {
+  const response = await ApiManager.post<{ id: number }>("/image/prepare-upload");
+  return response.data.id;
+};
+
+export const imageUpload = async (imageId: number, formData: FormData): Promise<ImageDTO> => {
+  const response = await ApiManager.post<{ result: ImageDTO }>(`/image/upload/${imageId}`, formData, {
+    headers: { "Content-Type": "multipart/form-data" },
+  });
+
+  return response.data.result;
+};

--- a/src/components/common/ImageUploadButton.tsx
+++ b/src/components/common/ImageUploadButton.tsx
@@ -1,0 +1,32 @@
+import styled from "@emotion/styled";
+import { Button } from "antd";
+import { uploadImage } from "../../utils/uploadImage";
+import { ImageDTO } from "../../types/image/dto";
+
+interface Props {
+  name: string;
+  handleChange: (image: ImageDTO) => void;
+}
+
+const ImageUploadButton: React.FC<Props> = ({ name, handleChange }) => {
+  const handleUploadImage = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const image = await uploadImage(file);
+    if (!image) return;
+
+    handleChange(image);
+  };
+
+  return (
+    <StyledButton>
+      <label htmlFor={name}>첨부하기</label>
+      <input type="file" id={name} name={name} onChange={handleUploadImage} hidden />
+    </StyledButton>
+  );
+};
+
+export default ImageUploadButton;
+
+const StyledButton = styled(Button)``;

--- a/src/types/image/dto.ts
+++ b/src/types/image/dto.ts
@@ -1,0 +1,4 @@
+export interface ImageDTO {
+  id: number;
+  url: string;
+}

--- a/src/utils/uploadImage.ts
+++ b/src/utils/uploadImage.ts
@@ -1,0 +1,18 @@
+import { imageUpload, prepareImageUpload } from "../api/image";
+import { ImageDTO } from "../types/image/dto";
+
+export const uploadImage = async (file: File): Promise<ImageDTO | null> => {
+  try {
+    const imageId = await prepareImageUpload();
+
+    const formData = new FormData();
+    formData.append("image", file);
+
+    const uploadedImage = await imageUpload(imageId, formData);
+
+    return uploadedImage;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};


### PR DESCRIPTION
## 작업 내용
이미지 업로드용 버튼 구현하였습니다. 일단 대충 기능만 구현했으며, 스타일은 후에 수정하도록 합시다.

## 테스트
이미지를 업로드하고 싶은 곳에 `ImageUploadButton`을 사용합시다.
(주의) 백엔드 이미지 관련 수정이 있습니다. `feat/modify-image-upload` 브랜치 사용 부탁드립니다.

`ImageUploadButton`은 두 개의 Props를 받습니다.
- `name`은 버튼 고유값을 의미합니다.
- `handleChange`는 이미지 업로드 후의 받은 이미지 데이터 정보입니다. 이미지의 id와 url이 들어가있습니다.
  - id는 이미지 업로드 후, 상품을 post할 때 사용될 것이고, url은 이미지를 화면에 나타낼 때 사용하면 됩니다.

## 비고
- 어제 스크럼 때 css를 사용하자고 했는데, 이슈가 있어 styled를 사용해야할 것 같습니다....