### PR TITLE
Feature: 메인페이지 기능 추가

### DIFF
--- a/src/api/product/index.ts
+++ b/src/api/product/index.ts
@@ -10,7 +10,7 @@ export const getPopularProducts = async () => {
   return response.data;
 };
 
-export const getDeptPopularProducts = async (departmentId: number) => {
-  const response = await ApiManager.get(`/products?sort=popular&page=1&pageSize=4&departmentId=${departmentId}`);
+export const getDeptPopularProducts = async (departmentId: number, page: number = 1) => {
+  const response = await ApiManager.get(`/products?sort=popular&page=${page}&pageSize=4&departmentId=${departmentId}`);
   return response.data;
 };

--- a/src/components/common/LinksInNav.tsx
+++ b/src/components/common/LinksInNav.tsx
@@ -13,6 +13,7 @@ const LinksInNav = () => {
   const handleSignOut = () => {
     signOut();
     navigate("/");
+    window.location.reload();
   };
 
   if (isAuthenticated()) {

--- a/src/components/common/SearchSection.tsx
+++ b/src/components/common/SearchSection.tsx
@@ -1,18 +1,112 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
 import SearchInput from "./SearchSection/SearchInput";
-import DepartmentDropdown from "./SearchSection/DepartmentDropdown";
-import { Col, Row } from "antd";
+import { Col, ConfigProvider, Row, Select, Tooltip } from "antd";
+import { DepartmentDropdownInfo, DepartmentResDTO } from "../../models/department";
+import { useEffect, useState } from "react";
+import { getDepartments } from "../../api/department";
+import { getResponsiveValueByWindowWidth } from "../../styles/responsive";
+import { TooltipPlacement } from "antd/es/tooltip";
 
 const SearchSection = () => {
+  const [departments, setDepartments] = useState<DepartmentDropdownInfo[]>(dummyDepartments);
+  const [selectedValue, setSelectedValue] = useState<number>(0);
+  const [tooltipPlacement, setTooltipPlacement] = useState<TooltipPlacement>("top");
+  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
+
+  const handleChange = (value: number) => {
+    setSelectedValue(value);
+  };
+
+  const handleResize = () => {
+    setWindowWidth(window.innerWidth);
+  };
+
+  useEffect(() => {
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  useEffect(() => {
+    setTooltipPlacement(
+      getResponsiveValueByWindowWidth(windowWidth, {
+        md: "top",
+        xs: "bottom",
+      }),
+    );
+  }, [windowWidth]);
+
+  useEffect(() => {
+    const fetchDepartments = async () => {
+      const rawDepartments: DepartmentResDTO[] = await getDepartments();
+      const fetchedDepartments: DepartmentDropdownInfo[] = rawDepartments.map((rawDepartment) => {
+        return {
+          value: rawDepartment.id,
+          label: rawDepartment.departmentName,
+        };
+      });
+      return fetchedDepartments;
+    };
+
+    fetchDepartments().then((departments: DepartmentDropdownInfo[]) => {
+      const noDepartment: DepartmentDropdownInfo = {
+        value: 0,
+        label: "학과 상관 없이",
+      };
+
+      setDepartments(() => [noDepartment, ...departments]);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (selectedValue === undefined) setSelectedValue(0);
+    console.log(selectedValue);
+  }, [selectedValue]);
+
   return (
     <div css={SearchSectionStyle}>
       <Row gutter={16}>
         <Col xs={24} md={16} lg={18}>
-          <SearchInput />
+          <SearchInput departmentId={selectedValue} />
         </Col>
         <Col xs={24} md={8} lg={6}>
-          <DepartmentDropdown />
+          <ConfigProvider
+            theme={{
+              token: {
+                fontSize: 18,
+                fontSizeIcon: 12,
+              },
+              components: {
+                Select: {
+                  optionHeight: 40,
+                  optionPadding: 10,
+                },
+              },
+            }}
+          >
+            <Tooltip
+              title="원하는 학과의 상품만 찾아 보세요!"
+              trigger="hover"
+              overlayInnerStyle={{ fontSize: "14px" }}
+              placement={tooltipPlacement}
+            >
+              <Select
+                value={selectedValue}
+                dropdownStyle={{ padding: 10 }}
+                style={{
+                  width: "100%",
+                  height: "60px",
+                  textAlign: "center",
+                }}
+                onChange={handleChange}
+                options={departments}
+                allowClear
+              />
+            </Tooltip>
+          </ConfigProvider>
         </Col>
       </Row>
     </div>
@@ -25,3 +119,5 @@ const SearchSectionStyle = css`
 `;
 
 export default SearchSection;
+
+const dummyDepartments: DepartmentDropdownInfo[] = [];

--- a/src/components/common/SearchSection/DepartmentDropdown.tsx
+++ b/src/components/common/SearchSection/DepartmentDropdown.tsx
@@ -1,29 +1,42 @@
-import { Select, ConfigProvider } from "antd";
+import { Select, ConfigProvider, Tooltip } from "antd";
 import { getDepartments } from "../../../api/department";
 import { useEffect, useState } from "react";
 import { DepartmentDropdownInfo, DepartmentResDTO } from "../../../models/department";
 
-const handleChange = (value: string) => {
-  console.log(`selected ${value}`);
-};
-
 const DepartmentDropdown: React.FC = () => {
   const [departments, setDepartments] = useState<DepartmentDropdownInfo[]>(dummyDepartments);
+  const [selectedValue, setSelectedValue] = useState<number>(0);
+
+  const handleChange = (value: number) => {
+    setSelectedValue(value);
+  };
 
   useEffect(() => {
     const fetchDepartments = async () => {
       const rawDepartments: DepartmentResDTO[] = await getDepartments();
-      const fetchedDepartments = rawDepartments.map((rawDepartment) => {
+      const fetchedDepartments: DepartmentDropdownInfo[] = rawDepartments.map((rawDepartment) => {
         return {
           value: rawDepartment.id,
           label: rawDepartment.departmentName,
         };
       });
-      setDepartments(() => fetchedDepartments);
+      return fetchedDepartments;
     };
 
-    fetchDepartments();
+    fetchDepartments().then((departments: DepartmentDropdownInfo[]) => {
+      const noDepartment: DepartmentDropdownInfo = {
+        value: 0,
+        label: "학과 상관 없이",
+      };
+
+      setDepartments(() => [noDepartment, ...departments]);
+    });
   }, []);
+
+  useEffect(() => {
+    if (selectedValue === undefined) setSelectedValue(0);
+    console.log(selectedValue);
+  }, [selectedValue]);
 
   return (
     <ConfigProvider
@@ -41,17 +54,20 @@ const DepartmentDropdown: React.FC = () => {
         },
       }}
     >
-      <Select
-        defaultValue="학과 선택"
-        dropdownStyle={{ padding: 10 }}
-        style={{
-          width: "100%",
-          height: "60px",
-          textAlign: "center",
-        }}
-        onChange={handleChange}
-        options={departments}
-      />
+      <Tooltip title="원하는 학과의 상품만 찾아 보세요!" trigger="hover" overlayInnerStyle={{ fontSize: "14px" }}>
+        <Select
+          value={selectedValue}
+          dropdownStyle={{ padding: 10 }}
+          style={{
+            width: "100%",
+            height: "60px",
+            textAlign: "center",
+          }}
+          onChange={handleChange}
+          options={departments}
+          allowClear
+        />
+      </Tooltip>
     </ConfigProvider>
   );
 };

--- a/src/components/common/SearchSection/DepartmentDropdown.tsx
+++ b/src/components/common/SearchSection/DepartmentDropdown.tsx
@@ -42,19 +42,23 @@ const DepartmentDropdown: React.FC = () => {
     <ConfigProvider
       theme={{
         token: {
-          // NOTE: ts error가 뜨지만 잘 작동함. 똑같은 값이라도 그냥 number를 주는 거랑 px를 붙여서 주는 것이 시각적으로 다른 결과를 가져옴.
           fontSize: 18,
           fontSizeIcon: 12,
         },
         components: {
           Select: {
             optionHeight: 40,
-            optionPadding: 5,
+            optionPadding: 10,
           },
         },
       }}
     >
-      <Tooltip title="원하는 학과의 상품만 찾아 보세요!" trigger="hover" overlayInnerStyle={{ fontSize: "14px" }}>
+      <Tooltip
+        title="원하는 학과의 상품만 찾아 보세요!"
+        trigger="hover"
+        overlayInnerStyle={{ fontSize: "14px" }}
+        placement="top"
+      >
         <Select
           value={selectedValue}
           dropdownStyle={{ padding: 10 }}

--- a/src/components/common/SearchSection/SearchInput.tsx
+++ b/src/components/common/SearchSection/SearchInput.tsx
@@ -4,7 +4,11 @@ import { Input, Button, Space } from "antd";
 import { SearchOutlined } from "@ant-design/icons";
 import { useState } from "react";
 
-const SearchInput = () => {
+interface SearchInputProps {
+  departmentId?: number;
+}
+
+const SearchInput: React.FC<SearchInputProps> = ({ departmentId }) => {
   const [search, setSearch] = useState<string>("");
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -20,7 +24,7 @@ const SearchInput = () => {
           type="primary"
           icon={<SearchOutlined css={SearchIconStyle} />}
           css={SearchButtonStyle}
-          href={`/product?search=${search}`} // TODO: 검색 페이지 url 변동 가능성 있음
+          href={`/product?search=${search}${departmentId && departmentId > 0 ? `&departmentId=${departmentId}` : ""}`} // TODO: 검색 페이지 url 변동 가능성 있음
         ></Button>
       </Space.Compact>
     </>

--- a/src/pages/mainpage.tsx
+++ b/src/pages/mainpage.tsx
@@ -7,16 +7,25 @@ import HigherLayoutComponent from "../components/common/CustomLayout";
 import ItemList from "../components/common/ItemList";
 import SearchSection from "../components/common/SearchSection";
 import { ProductThumbnailInfo } from "../models/product";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { message, Flex } from "antd";
 import { COMMON_MESSAGE } from "../contants/message";
 import { getResponsiveValueByWindowWidth, sm_lower_bound, xl_lower_bound } from "../styles/responsive";
 import { DEPARTMENTS } from "../data/department";
+import { getCurrentUser } from "../api/user";
+import { DepartmentResDTO } from "../models/department";
+import { getDepartments } from "../api/department";
 
 const Main = () => {
+  const [departments, setDepartments] = useState<DepartmentResDTO[]>(dummyDepartments);
+
   const [recentProducts, setRecentProducts] = useState<ProductThumbnailInfo[]>(dummyProducts);
   const [popularProducts, setPopularProducts] = useState<ProductThumbnailInfo[]>(dummyProducts);
   const [deptPopularProducts, setDeptPopularProducts] = useState<ProductThumbnailInfo[]>(dummyProducts);
+  const [userDepartmentId, setUserDepartmentId] = useState<number>();
+  const [isSignedIn, SetIsSignedIn] = useState<boolean>(false);
+  const isWorthFetchingNextPageDeptPopularProducts = useRef<boolean>(true);
+  const fetchNextPageDeptPopularProductsCount = useRef<number>(0);
 
   const [windowWidth, setWindowWidth] = useState(window.innerWidth);
   const [maxItemCount, setMaxItemCount] = useState<number>(0);
@@ -24,6 +33,46 @@ const Main = () => {
   const handleResize = () => {
     setWindowWidth(window.innerWidth);
   };
+
+  useEffect(() => {
+    const fetchDepartments = async (): Promise<DepartmentResDTO[]> => {
+      return await getDepartments();
+    };
+
+    fetchDepartments().then((depts) => {
+      setDepartments(() => depts);
+    });
+  }, []);
+
+  useEffect(() => {
+    const fetchCurrentUserDepartmentId = async () => {
+      try {
+        const { departmentId } = await getCurrentUser();
+        SetIsSignedIn(true);
+        return departmentId;
+      } catch (error) {
+        SetIsSignedIn(false);
+
+        const [messageApi] = message.useMessage();
+        if (error instanceof AxiosError) {
+          messageApi.open({
+            type: "error",
+            content: error?.response?.data.message || COMMON_MESSAGE.SERVER_ERROR,
+          });
+          return;
+        } else {
+          messageApi.open({
+            type: "error",
+            content: COMMON_MESSAGE.UNKNOWN_ERROR,
+          });
+        }
+      }
+    };
+
+    fetchCurrentUserDepartmentId().then((departmentId) => {
+      setUserDepartmentId(departmentId);
+    });
+  }, []);
 
   useEffect(() => {
     handleResize();
@@ -119,56 +168,62 @@ const Main = () => {
       }
     };
 
-    const fetchDeptPopularProducts = async (departmentId: number) => {
-      try {
-        const rawProducts = await getDeptPopularProducts(departmentId);
-        const products: ProductThumbnailInfo[] = rawProducts.map((rawProduct: any) => {
-          const {
-            id,
-            productName,
-            departmentId,
-            currentHighestPrice,
-            upperBound,
-            lowerBound,
-            departmentBidderCount: bidderCount,
-            image,
-          } = rawProduct;
-          const product: ProductThumbnailInfo = {
-            id,
-            productName,
-            departmentName: DEPARTMENTS[departmentId].label,
-            lowerBound,
-            currentHighestPrice,
-            upperBound,
-            bidderCount,
-            imageUrl: image.url,
-          };
-          return product;
+    fetchRecentProducts();
+    fetchPopularProducts();
+  }, []);
+
+  const fetchDeptPopularProducts = async (departmentId: number, page: number = 1) => {
+    try {
+      const rawProducts = await getDeptPopularProducts(departmentId, page);
+      const products: ProductThumbnailInfo[] = rawProducts.map((rawProduct: any) => {
+        const {
+          id,
+          productName,
+          departmentId,
+          currentHighestPrice,
+          upperBound,
+          lowerBound,
+          departmentBidderCount: bidderCount,
+          image,
+        } = rawProduct;
+        const product: ProductThumbnailInfo = {
+          id,
+          productName,
+          departmentName: DEPARTMENTS[departmentId].label,
+          lowerBound,
+          currentHighestPrice,
+          upperBound,
+          bidderCount,
+          imageUrl: image.url,
+        };
+        return product;
+      });
+      return products;
+    } catch (error) {
+      const [messageApi] = message.useMessage();
+      if (error instanceof AxiosError) {
+        messageApi.open({
+          type: "error",
+          content: error?.response?.data.message || COMMON_MESSAGE.SERVER_ERROR,
         });
+        return;
+      } else {
+        messageApi.open({
+          type: "error",
+          content: COMMON_MESSAGE.UNKNOWN_ERROR,
+        });
+      }
+    }
+  };
+
+  useEffect(() => {
+    userDepartmentId &&
+      fetchDeptPopularProducts(userDepartmentId).then((products) => {
         if (products) {
           setDeptPopularProducts(() => products);
         }
-      } catch (error) {
-        const [messageApi] = message.useMessage();
-        if (error instanceof AxiosError) {
-          messageApi.open({
-            type: "error",
-            content: error?.response?.data.message || COMMON_MESSAGE.SERVER_ERROR,
-          });
-          return;
-        } else {
-          messageApi.open({
-            type: "error",
-            content: COMMON_MESSAGE.UNKNOWN_ERROR,
-          });
-        }
-      }
-    };
-
-    fetchRecentProducts();
-    fetchPopularProducts();
-    fetchDeptPopularProducts(2); // TODO: 로그인 유저 학과 id로 대체
-  }, []);
+      });
+  }, [userDepartmentId]);
 
   useEffect(() => {
     const deptPopularProductsWithoutOverlap = deptPopularProducts.filter((product) => {
@@ -181,8 +236,21 @@ const Main = () => {
     });
     if (JSON.stringify(deptPopularProducts) !== JSON.stringify(deptPopularProductsWithoutOverlap)) {
       setDeptPopularProducts(() => deptPopularProductsWithoutOverlap);
+      if (deptPopularProductsWithoutOverlap.length < 4) {
+        userDepartmentId &&
+          fetchDeptPopularProducts(userDepartmentId, fetchNextPageDeptPopularProductsCount.current + 2).then(
+            (products) => {
+              fetchNextPageDeptPopularProductsCount.current += 1;
+              if (isWorthFetchingNextPageDeptPopularProducts.current && products && products.length > 0) {
+                setDeptPopularProducts((prev) => [...prev, ...products]);
+              } else {
+                isWorthFetchingNextPageDeptPopularProducts.current = false;
+              }
+            },
+          );
+      }
     }
-  }, [deptPopularProducts, popularProducts]);
+  }, [deptPopularProducts, popularProducts, userDepartmentId]);
 
   return (
     <Flex vertical css={SpaceStyle}>
@@ -192,17 +260,24 @@ const Main = () => {
         products={popularProducts}
         maxItemCount={maxItemCount}
         moreUrl=""
-        showBidderCount
-      />
-      <ItemList title="최근에 올라온" products={recentProducts} maxItemCount={maxItemCount} moreUrl="" showMore />
-      <ItemList
-        title="경영학과에서 많이 찾는" // TODO: 로그인 유저 학과로 대체
-        products={deptPopularProducts}
-        maxItemCount={maxItemCount}
-        moreUrl=""
         showMore
         showBidderCount
       />
+      <ItemList title="최근에 올라온" products={recentProducts} maxItemCount={maxItemCount} moreUrl="" showMore />
+      {isSignedIn ? (
+        <ItemList
+          title={`${
+            userDepartmentId && departments.length > 0 ? departments[userDepartmentId - 1].departmentName : ""
+          }에서 많이 찾는`}
+          products={deptPopularProducts}
+          maxItemCount={maxItemCount}
+          moreUrl=""
+          showMore
+          showBidderCount
+        />
+      ) : (
+        <></>
+      )}
     </Flex>
   );
 };
@@ -225,3 +300,4 @@ const SpaceStyle = css`
 `;
 
 const dummyProducts: ProductThumbnailInfo[] = [];
+const dummyDepartments: DepartmentResDTO[] = [];


### PR DESCRIPTION
## 작업 내용
1. "전체 인기 상품"과 "학과 인기 상품"의 항목이 겹치지 않도록 하는 기능을 완성했습니다.
  - 학과 인기 상품 조회 API를 필요한 만큼 호출
![스크린샷 2024-01-16 152719](https://github.com/KWEBofficial/kubid-client/assets/115782193/8de0d285-813d-4177-b11b-dc245c4959b8)
2. "학과 인기 상품"이 현재 로그인 유저의 학과를 따르게 하고, 비로그인 유저에게는 보이지 않게 했습니다.
3. 학과 선택 목록에 툴팁을 추가하고, 검색 버튼을 누를 시 학과 선택 정보도 쿼리로 들어가도록 했습니다. (해당 학과의 상품만 검색)
  - 근데 서버 api 쪽에서 해당 학과의 상품만 검색하는 기능을 반영하지 않아서 제가 수정할 예정입니다
  - 오른쪽 ⓧ 버튼을 누르면 "학과 상관 없이"로 설정
![image](https://github.com/KWEBofficial/kubid-client/assets/115782193/23152498-a0c5-4c76-b344-0c24bd5c3419)
![image](https://github.com/KWEBofficial/kubid-client/assets/115782193/358df3bf-d644-4207-9ef7-da8591edc72a)
