### PR TITLE
fix: 검색 페이지 minor fix & 메인 페이지 minor logic 수정

### DIFF
--- a/src/components/common/SearchSection/SearchInput.tsx
+++ b/src/components/common/SearchSection/SearchInput.tsx
@@ -15,7 +15,6 @@ const SearchInput: React.FC<SearchInputProps> = ({ departmentId, defaultValue })
   const defaultPageSize = 4;
 
   const params = new URLSearchParams(window.location.search);
-  const page = Number(params.get("page")) || 1;
   const pageSize = Number(params.get("pageSize")) || 4;
 
   const inputRef = useRef<InputRef>(null);
@@ -30,7 +29,7 @@ const SearchInput: React.FC<SearchInputProps> = ({ departmentId, defaultValue })
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handlePressEnter = (e: any) => {
     navigate(
-      `/products?search=${e.target.value}&sort=recent&page=${page}&pageSize=${pageSize}${
+      `/products?search=${e.target.value}&sort=recent&page=1&pageSize=${pageSize}${
         departmentId && departmentId > 0 ? `&departmentId=${departmentId}` : ""
       }`,
     );

--- a/src/pages/mainpage.tsx
+++ b/src/pages/mainpage.tsx
@@ -175,16 +175,8 @@ const Main = () => {
       try {
         const rawProducts = await getDeptPopularProducts(departmentId, page);
         const products: ProductThumbnailInfo[] = rawProducts.map((rawProduct: any) => {
-          const {
-            id,
-            productName,
-            departmentId,
-            currentHighestPrice,
-            upperBound,
-            lowerBound,
-            departmentBidderCount: bidderCount,
-            image,
-          } = rawProduct;
+          const { id, productName, departmentId, currentHighestPrice, upperBound, lowerBound, bidderCount, image } =
+            rawProduct;
           const product: ProductThumbnailInfo = {
             id,
             productName,


### PR DESCRIPTION
- 검색창에서 Enter를 눌렀을 때 검색 결과를 1페이지부터 보여주지 않는 버그 fix
- 메인 페이지의 '학과 인기 상품'에 뜨는 현재 입찰자 수 기준 변경 (사유: 전체 인기 상품에 표시되는 입찰자 수와 일관성 유지)
  - 기존: 해당 학과 소속 입찰자 수만 표시
  - 변경: 전체 입찰자 수를 표시